### PR TITLE
FIX: REDO LAYER ON EXISTING TWEETS

### DIFF
--- a/client/app/dbPanel/dbPanel.html
+++ b/client/app/dbPanel/dbPanel.html
@@ -57,7 +57,7 @@
       <form ng-submit="startDownload()">
         <span>Stream Tweets Into DB</span>
         <div class="form-group">
-          <label for="stream-download-rate">Stream download rate</label>
+          <label for="stream-download-rate">Limit to Every Nth Tweet</label>
           <input type="number" class="form-control" ng-model="streamDownloadRate" placeholder="3">
         </div>
         <button class="btn btn-success">Start!</button>

--- a/server/ioroutes.js
+++ b/server/ioroutes.js
@@ -152,7 +152,7 @@ module.exports = function(io, T) {
             if(!db || !db.isLive){
               console.log("WAITING FOR DB");
               return;
-          }
+            }
             db.executeFullChainForIncomingTweets(tweet, function(err, container, fields) {
               if (err) {
                 console.log(err);


### PR DESCRIPTION
stream now works with max download rate without queue
redoing layers on existing database works, but needs perfomance
increases with better bulk lookups and another async callout
to the new asyncChain function.