### PR TITLE
FEATURE: deep dive on bulk processing for backlogged tweets

### DIFF
--- a/client/app/dbPanel/dbPanel.html
+++ b/client/app/dbPanel/dbPanel.html
@@ -34,6 +34,8 @@
     </div><div id="admin_layers_controls" class="box">
         <input type="text" class="form-control" ng-model="layerName" placeholder="Layer Name"><button ng-click="addNewLayer()" class="btn btn-success">Add Layer</button><button ng-click="redoLayer()" class="btn btn-warning">Run Layer</button>
         <button ng-click="deleteLayer()" class="btn btn-danger">Delete Layer</button>
+        <button ng-click="REDOALLLAYERS()" class="btn btn-danger">REDO ALL LAYERS!</button>
+
 
 
     </div><div id="admin_tables_display" class="box">

--- a/client/app/dbPanel/dbPanel.js
+++ b/client/app/dbPanel/dbPanel.js
@@ -160,6 +160,17 @@ angular.module('parserApp')
       });
     };
 
+    $scope.REDOALLLAYERS = function(){
+
+       $http.post('/auth/adminlogin/processLayersForExistingTweets', {})
+      .success(function(data) {
+
+      })
+      .error(function(data){
+
+      });
+    }
+
     $scope.deleteLayer = function(name) {
       name = name || $scope.layerName;
       $http.post('/auth/adminlogin/deleteLayer', {name: name})
@@ -289,11 +300,11 @@ angular.module('parserApp')
     $scope.changeToDatabase = function(name) {
 
       name = name || $scope.databaseName;
-      if(name === $scope.currDB){
-        $scope.setRightStatus(3000,"ERROR: provide valid name.");
-        $scope.setLeftStatus(3000);
-        return;
-      }
+      // if(name === $scope.currDB){
+      //   $scope.setRightStatus(3000,"ERROR: provide valid name.");
+      //   $scope.setLeftStatus(3000);
+      //   return;
+      // }
       $scope.setLeftStatus(null,"CLIENT: CHANGE DB: " + name);
       if(!name){
         $scope.setRightStatus(3000,"ERROR: provide valid name.");

--- a/server/auth/adminlogin/index.js
+++ b/server/auth/adminlogin/index.js
@@ -184,6 +184,25 @@ router.post('/redoLayer', function(req, res, next) {
     });
 });
 
+
+
+router.post('/processLayersForExistingTweets', function(req, res, next) {
+  db.processLayersForExistingTweets(null,null, function(err, rows) {
+
+
+    if(err){
+      console.log(err);
+      res.send(false);
+      return;
+    }
+      res.send(true);
+  },function(){
+    console.log("DONE REDOING ALL LAYERS");
+
+  });
+});
+
+
 router.post('/deleteLayer', function(req, res, next) {
   var name = req.body.name;
   db.deleteLayer(name, function(err, rows) {


### PR DESCRIPTION
-this includes a toggle on the current generic table add that forces it to compile tweets.
-it also allows all layers to be processed at once for a block of tweets within an id range, or by default, all tweets.
-this also required a backwards overall function to handle setting up unique on columns. this commit also includes the test functionality added to dev panel.