### PR TITLE
FIX: Stream now uses fast chunk system

### DIFF
--- a/server/ioroutes.js
+++ b/server/ioroutes.js
@@ -159,7 +159,6 @@ module.exports = function(io, T) {
         var rate = rate || 3;
 
         io.streamDownload.on('tweet', function(tweet) {
-          console.log();
           if(io.listenToTweetStream === false){
             return;
           }
@@ -172,13 +171,12 @@ module.exports = function(io, T) {
                 console.log("WAITING FOR DB");
                 return;
               }
-              db.executeFullChainForIncomingTweets(tweet, function(err, container, fields) {
+              db.executeFullChainForIncomingTweets(tweet, function(err, message, fields) {
                 if (err) {
                   console.log(err);
                   return;
                 } else {
-                  //moved into database module.
-                  // exports.io.emit('tweet added', container);
+                  console.log(message);
 
                 }
               });
@@ -190,7 +188,7 @@ module.exports = function(io, T) {
 
     var boundStart = io.startTweetDownload.bind(this, io);
 
-     socket.on('start download', function(rate){
+    socket.on('start download', function(rate){
       boundStart(rate);
     });
 


### PR DESCRIPTION
Server, if set to use production database, will now enable the stream by default on its own. When disconnected from the database, it will reboot the connection and start the stream again.
The server currently queues 50 tweets from the stream in a chunk before processing and sending to the client. This can be raised or lowerd by a variable at the top of database.js.