### PR TITLE
Added dummy func for finalCB to route

### DIFF
--- a/server/ioroutes.js
+++ b/server/ioroutes.js
@@ -132,7 +132,7 @@ module.exports = function(io, T) {
         return;
       }
 
-       db.sendTweetPackagesForKeywordToClient(keyword, clientID, function(err, result){});
+       db.sendTweetPackagesForKeywordToClient(keyword, clientID, function(err, result){}, function(){});
       //callback will either return error, or the name of the keyword if it exists
 
     });


### PR DESCRIPTION
New version of stream keyword also included an option for a finalCB to server. Which the test case had, but dind't update the original call the client uses.